### PR TITLE
Sonance fixes

### DIFF
--- a/pyxantech/__init__.py
+++ b/pyxantech/__init__.py
@@ -361,6 +361,40 @@ def _zone_status_cmd(amp_type: str, zone: int) -> bytes:
     return _command(amp_type, 'zone_status', args={'zone': zone})
 
 
+def _zone_status_query_commands(amp_type: str, zone: int) -> list[tuple[str, bytes]] | None:
+    """Return list of (query_name, command) pairs if protocol uses multi-query zone status."""
+    zones = _get_valid_zones(amp_type)
+    if zone not in zones:
+        raise ValueError(f'Invalid zone {zone} for amp type {amp_type}')
+    queries = get_protocol_config(amp_type, 'zone_status_queries')
+    if not queries:
+        return None
+    return [(q, _command(amp_type, q, args={'zone': zone})) for q in queries]
+
+
+def _merge_zone_status_responses(amp_type: str, responses: list[tuple[str, str]]) -> dict | None:
+    """Merge named-group captures from multiple query responses into one dict."""
+    protocol_type = get_device_config(amp_type, 'protocol')
+    patterns = RS232_RESPONSE_PATTERNS.get(protocol_type, {})
+    status_translation = get_protocol_config(amp_type, 'status_translation')
+    merged: dict = {}
+    for query_name, response in responses:
+        if not response:
+            continue
+        pattern = patterns.get(query_name)
+        if pattern is None:
+            continue
+        m = pattern.search(response)
+        if m:
+            groups = m.groupdict()
+            if status_translation:
+                for key, value in groups.items():
+                    if key in status_translation and value in status_translation[key]:
+                        groups[key] = status_translation[key][value]
+            merged.update(groups)
+    return merged if merged else None
+
+
 def _set_power_cmd(amp_type: str, zone: int, power: bool) -> bytes:
     """Build power control command."""
     zones = _get_valid_zones(amp_type)
@@ -549,6 +583,12 @@ def get_amp_controller(
         @synchronized
         def zone_status(self, zone: int) -> dict[str, Any] | None:
             skip = get_device_config(amp_type, 'zone_status_skip', log_missing=False) or 0
+            queries = _zone_status_query_commands(self._amp_type, zone)
+            if queries:
+                responses = [(name, self._send_request(cmd, skip)) for name, cmd in queries]
+                merged = _merge_zone_status_responses(self._amp_type, responses)
+                LOG.debug('Zone status (multi-query): merged=%s', merged)
+                return ZoneStatus.from_dict(merged).dict if merged else None
             response = self._send_request(_zone_status_cmd(self._amp_type, zone), skip)
             status = ZoneStatus.from_string(self._amp_type, response)
             LOG.debug('Zone status: status=%s, raw=%s', status, response)
@@ -670,10 +710,15 @@ async def async_get_amp_controller(
 
         @locked_coro
         async def zone_status(self, zone: int) -> dict[str, Any] | None:
-            cmd = _zone_status_cmd(self._amp_type, zone)
             skip = get_device_config(amp_type, 'zone_status_skip', log_missing=False) or 0
+            queries = _zone_status_query_commands(self._amp_type, zone)
+            if queries:
+                responses = [(name, await self._protocol.send(cmd, skip=skip)) for name, cmd in queries]
+                merged = _merge_zone_status_responses(self._amp_type, responses)
+                LOG.debug('Zone status (multi-query): merged=%s', merged)
+                return ZoneStatus.from_dict(merged).dict if merged else None
+            cmd = _zone_status_cmd(self._amp_type, zone)
             status_string = await self._protocol.send(cmd, skip=skip)
-
             status = ZoneStatus.from_string(self._amp_type, status_string)
             LOG.debug('Zone status: status=%s, raw=%s', status, status_string)
             return status.dict if status else None

--- a/pyxantech/__init__.py
+++ b/pyxantech/__init__.py
@@ -372,26 +372,57 @@ def _zone_status_query_commands(amp_type: str, zone: int) -> list[tuple[str, byt
     return [(q, _command(amp_type, q, args={'zone': zone})) for q in queries]
 
 
-def _merge_zone_status_responses(amp_type: str, responses: list[tuple[str, str]]) -> dict | None:
-    """Merge named-group captures from multiple query responses into one dict."""
+def _merge_zone_status_responses(
+    amp_type: str,
+    zone: int,
+    responses: list[tuple[str, list[str]]],
+) -> dict | None:
+    """Merge named-group captures from multiple query responses into one dict.
+
+    For each query, all returned lines are scanned for the first match whose
+    zone field (if present) matches the queried zone. This handles amps that
+    batch multiple response lines into one serial/TCP packet.
+    """
     protocol_type = get_device_config(amp_type, 'protocol')
     patterns = RS232_RESPONSE_PATTERNS.get(protocol_type, {})
     status_translation = get_protocol_config(amp_type, 'status_translation')
     merged: dict = {}
-    for query_name, response in responses:
-        if not response:
+    matched = 0
+    for query_name, lines in responses:
+        if not lines:
+            LOG.debug('No response lines for query: query=%s, zone=%s', query_name, zone)
             continue
         pattern = patterns.get(query_name)
         if pattern is None:
             continue
-        m = pattern.search(response)
-        if m:
+        for line in lines:
+            m = pattern.search(line)
+            if not m:
+                continue
             groups = m.groupdict()
+            if 'zone' in groups and groups['zone'] != str(zone):
+                LOG.debug(
+                    'Skipping response for wrong zone: expected=%s, got=%s, query=%s, line=%s',
+                    zone, groups['zone'], query_name, line,
+                )
+                continue
             if status_translation:
                 for key, value in groups.items():
                     if key in status_translation and value in status_translation[key]:
                         groups[key] = status_translation[key][value]
             merged.update(groups)
+            matched += 1
+            break
+        else:
+            LOG.debug(
+                'No matching line for query: query=%s, zone=%s, lines=%s',
+                query_name, zone, lines,
+            )
+    if matched < len(responses):
+        LOG.debug(
+            'Partial zone status: zone=%s, matched=%d/%d queries',
+            zone, matched, len(responses),
+        )
     return merged if merged else None
 
 
@@ -585,10 +616,13 @@ def get_amp_controller(
             skip = get_device_config(amp_type, 'zone_status_skip', log_missing=False) or 0
             queries = _zone_status_query_commands(self._amp_type, zone)
             if queries:
-                responses = [(name, self._send_request(cmd, skip)) for name, cmd in queries]
-                merged = _merge_zone_status_responses(self._amp_type, responses)
+                responses = [(name, [self._send_request(cmd, skip)]) for name, cmd in queries]
+                merged = _merge_zone_status_responses(self._amp_type, zone, responses)
                 LOG.debug('Zone status (multi-query): merged=%s', merged)
-                return ZoneStatus.from_dict(merged).dict if merged else None
+                if not merged:
+                    return None
+                status = ZoneStatus.from_dict(merged)
+                return {k: v for k, v in status.dict.items() if k in merged}
             response = self._send_request(_zone_status_cmd(self._amp_type, zone), skip)
             status = ZoneStatus.from_string(self._amp_type, response)
             LOG.debug('Zone status: status=%s, raw=%s', status, response)
@@ -714,11 +748,15 @@ async def async_get_amp_controller(
             queries = _zone_status_query_commands(self._amp_type, zone)
             if queries:
                 responses = [(name, await self._protocol.send(cmd, skip=skip)) for name, cmd in queries]
-                merged = _merge_zone_status_responses(self._amp_type, responses)
+                merged = _merge_zone_status_responses(self._amp_type, zone, responses)
                 LOG.debug('Zone status (multi-query): merged=%s', merged)
-                return ZoneStatus.from_dict(merged).dict if merged else None
+                if not merged:
+                    return None
+                status = ZoneStatus.from_dict(merged)
+                return {k: v for k, v in status.dict.items() if k in merged}
             cmd = _zone_status_cmd(self._amp_type, zone)
-            status_string = await self._protocol.send(cmd, skip=skip)
+            lines = await self._protocol.send(cmd, skip=skip)
+            status_string = lines[0] if lines else ''
             status = ZoneStatus.from_string(self._amp_type, status_string)
             LOG.debug('Zone status: status=%s, raw=%s', status, status_string)
             return status.dict if status else None

--- a/pyxantech/__init__.py
+++ b/pyxantech/__init__.py
@@ -408,7 +408,8 @@ def _set_treble_cmd(amp_type: str, zone: int, treble: int) -> bytes:
         raise ValueError(f'Invalid zone {zone} for amp type {amp_type}')
 
     max_treble = get_device_config(amp_type, 'max_treble') or 14
-    treble = int(max(0, min(treble, max_treble)))
+    min_treble = get_device_config(amp_type, 'min_treble', log_missing=False) or 0
+    treble = int(max(min_treble, min(treble, max_treble)))
     LOG.info('Setting treble: amp_type=%s, zone=%s, treble=%s', amp_type, zone, treble)
     return _command(amp_type, 'set_treble', args={'zone': zone, 'treble': treble})
 
@@ -420,7 +421,8 @@ def _set_bass_cmd(amp_type: str, zone: int, bass: int) -> bytes:
         raise ValueError(f'Invalid zone {zone} for amp type {amp_type}')
 
     max_bass = get_device_config(amp_type, 'max_bass') or 14
-    bass = int(max(0, min(bass, max_bass)))
+    min_bass = get_device_config(amp_type, 'min_bass', log_missing=False) or 0
+    bass = int(max(min_bass, min(bass, max_bass)))
     LOG.info('Setting bass: amp_type=%s, zone=%s, bass=%s', amp_type, zone, bass)
     return _command(amp_type, 'set_bass', args={'zone': zone, 'bass': bass})
 
@@ -432,7 +434,8 @@ def _set_balance_cmd(amp_type: str, zone: int, balance: int) -> bytes:
         raise ValueError(f'Invalid zone {zone} for amp type {amp_type}')
 
     max_balance = get_device_config(amp_type, 'max_balance') or 20
-    balance = max(0, min(balance, max_balance))
+    min_balance = get_device_config(amp_type, 'min_balance', log_missing=False) or 0
+    balance = max(min_balance, min(balance, max_balance))
     LOG.info('Setting balance: amp_type=%s, zone=%s, balance=%s', amp_type, zone, balance)
     return _command(amp_type, 'set_balance', args={'zone': zone, 'balance': balance})
 

--- a/pyxantech/protocol.py
+++ b/pyxantech/protocol.py
@@ -159,7 +159,7 @@ class RS232ControlProtocol(asyncio.Protocol):
         *,
         wait_for_reply: bool = True,
         skip: int = 0,
-    ) -> str:
+    ) -> list[str]:
         """Send command and optionally wait for response.
 
         Args:
@@ -168,14 +168,15 @@ class RS232ControlProtocol(asyncio.Protocol):
             skip: Number of bytes to skip when looking for EOL.
 
         Returns:
-            Response string, or empty string if no reply expected/received.
+            List of response lines (may be >1 if amp batches responses).
+            Empty list if no reply expected or connection failed.
 
         Raises:
             asyncio.TimeoutError: If response not received within timeout.
         """
         async with self._lock:
             if not await self._wait_for_connection():
-                return ''
+                return []
 
             await self._throttle_requests()
 
@@ -190,18 +191,22 @@ class RS232ControlProtocol(asyncio.Protocol):
             self._transport.serial.write(request)
 
             if not wait_for_reply:
-                return ''
+                return []
 
             return await self._read_response(skip)
 
-    async def _read_response(self, skip: int) -> str:
+    async def _read_response(self, skip: int) -> list[str]:
         """Read and parse response from serial port.
+
+        Returns all complete lines received before the timeout. The amp may
+        batch multiple responses into a single TCP/serial packet, so callers
+        must not assume exactly one line is returned.
 
         Args:
             skip: Number of bytes to skip when looking for EOL.
 
         Returns:
-            Parsed response string.
+            List of decoded response lines (empty strings filtered out).
 
         Raises:
             asyncio.TimeoutError: If response not received within timeout.
@@ -215,6 +220,14 @@ class RS232ControlProtocol(asyncio.Protocol):
                 data += chunk
 
                 if response_eol in data[skip:]:
+                    # Drain any additional data already queued (non-blocking).
+                    # Unsolicited amp broadcasts and the actual query response
+                    # sometimes arrive in rapid succession across separate TCP
+                    # packets. Grabbing everything already in the queue gives
+                    # zone validation a better chance of finding the right line.
+                    while not self._queue.empty():
+                        data += self._queue.get_nowait()
+
                     decoded = bytes(data).decode('ascii', errors='ignore')
                     LOG.debug(
                         'Received response: data=%s, length=%d, eol=%s',
@@ -223,21 +236,16 @@ class RS232ControlProtocol(asyncio.Protocol):
                         response_eol,
                     )
 
-                    result_lines = [
-                        line for line in data.split(response_eol)
+                    lines = [
+                        line.decode('ascii', errors='ignore')
+                        for line in data.split(response_eol)
                         if line
                     ]
 
-                    if not result_lines:
-                        return ''
+                    if len(lines) > 1:
+                        LOG.debug('Multiple response lines received: lines=%s', lines)
 
-                    if len(result_lines) > 1:
-                        LOG.debug(
-                            'Multiple response lines, using first: lines=%s',
-                            result_lines,
-                        )
-
-                    return result_lines[0].decode('ascii', errors='ignore')
+                    return lines
 
         except asyncio.TimeoutError:
             # rate-limited logging to avoid log saturation

--- a/pyxantech/protocol.py
+++ b/pyxantech/protocol.py
@@ -121,7 +121,7 @@ class RS232ControlProtocol(asyncio.Protocol):
 
     def data_received(self, data: bytes) -> None:
         """Handle incoming data from serial port."""
-        asyncio.ensure_future(self._queue.put(data))
+        self._queue.put_nowait(data)
 
     def connection_lost(self, exc: Exception | None) -> None:
         """Handle connection closure."""

--- a/pyxantech/protocols/sonance.yaml
+++ b/pyxantech/protocols/sonance.yaml
@@ -57,6 +57,8 @@
     source_select: ':S{zone}{source}'
 
     balance_status: ':B{zone}?'
+    # Sonance requires an explicit sign prefix and 2-digit magnitude (e.g. +02, -08, +00).
+    # The :+03d format produces this — standard zero-padded unsigned values are rejected.
     set_balance:   ':B{zone}{balance:+03d}'
     balance_left:  ':B{zone}--'
     balance_right: ':B{zone}++'

--- a/pyxantech/protocols/sonance.yaml
+++ b/pyxantech/protocols/sonance.yaml
@@ -57,17 +57,17 @@
     source_select: ':S{zone}{source}'
 
     balance_status: ':B{zone}?'
-    set_balance:   ':B{zone}{balance:02}'
+    set_balance:   ':B{zone}{balance:+03d}'
     balance_left:  ':B{zone}--'
     balance_right: ':B{zone}++'
 
     bass_status:   ':L{zone}?'
-    set_bass:      ':L{zone}{bass:02}'
+    set_bass:      ':L{zone}{bass:+03d}'
     bass_up:       ':L{zone}++'
     bass_down:     ':L{zone}--'
 
     treble_status: ':H{zone}?'
-    set_treble:    ':H{zone}{treble:02}'
+    set_treble:    ':H{zone}{treble:+03d}'
     treble_up:     ':H{zone}++'
     treble_down:   ':H{zone}--'
 
@@ -80,11 +80,20 @@
     power_status:   '\+Z(?P<zone>\d+)(?P<power>[01])'
     zone_status:    '\+Z(?P<zone>\d+)(?P<power>[01])'
     source_status:  '\+S(?P<zone>\d+)(?P<source>[1-4])'
-    volume_status:  '\+V(?P<zone>\d+)(?P<volume>\d+)'
+    volume_status:  '\+V(?P<zone>[1-6])(?P<volume>\d+)'
     mute_status:    '\+M(?P<zone>\d+)(?P<mute>[01])'
-    treble_status:  '\+H(?P<zone>\d+)TR(?P<treble>\d+)'
-    bass_status:    '\+L(?P<zone>\d+)BS(?P<bass>\d+)'
-    balance_status: '\+B(?P<zone>\d+)BA(?P<balance>\d+)'
+    treble_status:  '\+H(?P<zone>\d+)(?P<treble>[+-]?\d+)'
+    bass_status:    '\+L(?P<zone>\d+)(?P<bass>[+-]?\d+)'
+    balance_status: '\+B(?P<zone>\d+)(?P<balance>[+-]?\d+)'
+
+  zone_status_queries:
+    - zone_status
+    - volume_status
+    - source_status
+    - mute_status
+    - bass_status
+    - treble_status
+    - balance_status
 
   extras:
     restore_zone:    [ 'set_power', 'set_source', 'set_volume', 'set_mute', 'set_bass', 'set_balance', 'set_treble' ]

--- a/pyxantech/series/sonance6.yaml
+++ b/pyxantech/series/sonance6.yaml
@@ -34,8 +34,11 @@
   num_sources: 4
 
   # FIXME: the limits should come from
+  min_balance: -10
   max_balance: 10
+  min_bass: -8
   max_bass: 8
+  min_treble: -8
   max_treble: 8
   max_volume: 60
 

--- a/tests/test_sonance.py
+++ b/tests/test_sonance.py
@@ -1,0 +1,165 @@
+"""Tests for Sonance C4630 SE protocol support."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyxantech import (
+    _merge_zone_status_responses,
+    _set_balance_cmd,
+    _set_bass_cmd,
+    _set_treble_cmd,
+    _set_volume_cmd,
+    _zone_status_cmd,
+    _zone_status_query_commands,
+)
+
+
+class TestSonanceCommands:
+    """Tests for Sonance protocol command generation."""
+
+    def test_zone_status_command(self) -> None:
+        """Verify Sonance zone status query format."""
+        assert _zone_status_cmd('sonance6', 1) == b':Z1?\r'
+        assert _zone_status_cmd('sonance6', 6) == b':Z6?\r'
+
+    def test_volume_command(self) -> None:
+        """Verify volume command uses 2-digit zero-padded format."""
+        assert _set_volume_cmd('sonance6', 1, 40) == b':V140\r'
+        assert _set_volume_cmd('sonance6', 2, 5)  == b':V205\r'
+        assert _set_volume_cmd('sonance6', 3, 60) == b':V360\r'
+
+    def test_bass_positive(self) -> None:
+        """Positive bass uses explicit + sign and 2-digit magnitude."""
+        assert _set_bass_cmd('sonance6', 1, 5)  == b':L1+05\r'
+        assert _set_bass_cmd('sonance6', 2, 8)  == b':L2+08\r'
+
+    def test_bass_negative(self) -> None:
+        """Negative bass uses - sign; standard zero-pad would produce wrong output."""
+        assert _set_bass_cmd('sonance6', 1, -5) == b':L1-05\r'
+        assert _set_bass_cmd('sonance6', 2, -8) == b':L2-08\r'
+
+    def test_bass_zero(self) -> None:
+        """Zero bass uses + sign per Sonance protocol."""
+        assert _set_bass_cmd('sonance6', 1, 0)  == b':L1+00\r'
+
+    def test_treble_signed(self) -> None:
+        """Treble uses the same signed format as bass."""
+        assert _set_treble_cmd('sonance6', 1,  7) == b':H1+07\r'
+        assert _set_treble_cmd('sonance6', 1, -7) == b':H1-07\r'
+        assert _set_treble_cmd('sonance6', 1,  0) == b':H1+00\r'
+
+    def test_balance_signed(self) -> None:
+        """Balance uses signed format; range is -10..+10."""
+        assert _set_balance_cmd('sonance6', 1,  10) == b':B1+10\r'
+        assert _set_balance_cmd('sonance6', 1, -10) == b':B1-10\r'
+        assert _set_balance_cmd('sonance6', 1,   0) == b':B1+00\r'
+        assert _set_balance_cmd('sonance6', 1,   2) == b':B1+02\r'
+
+    def test_invalid_zone_raises(self) -> None:
+        """Zone 0 and zone 7 are invalid for sonance6."""
+        with pytest.raises(ValueError, match='Invalid zone'):
+            _zone_status_cmd('sonance6', 0)
+        with pytest.raises(ValueError, match='Invalid zone'):
+            _zone_status_cmd('sonance6', 7)
+
+
+class TestSonanceMultiQuery:
+    """Tests for multi-query zone_status_queries support."""
+
+    def test_returns_seven_queries(self) -> None:
+        """zone_status_queries should expand to 7 command/name pairs."""
+        queries = _zone_status_query_commands('sonance6', 1)
+        assert queries is not None
+        assert len(queries) == 7
+
+    def test_query_names(self) -> None:
+        """Verify the expected query names are present."""
+        queries = _zone_status_query_commands('sonance6', 1)
+        names = [name for name, _ in queries]
+        assert 'zone_status'   in names
+        assert 'volume_status' in names
+        assert 'source_status' in names
+        assert 'mute_status'   in names
+        assert 'bass_status'   in names
+        assert 'treble_status' in names
+        assert 'balance_status' in names
+
+    def test_query_commands_contain_zone(self) -> None:
+        """Each query command should encode the correct zone number."""
+        queries = _zone_status_query_commands('sonance6', 3)
+        for _name, cmd in queries:
+            assert b'3' in cmd
+
+
+class TestMergeZoneStatusResponses:
+    """Tests for _merge_zone_status_responses zone validation and line scanning."""
+
+    def test_correct_zone_is_merged(self) -> None:
+        """Response matching the queried zone is merged."""
+        responses = [
+            ('zone_status',   ['+Z11']),
+            ('volume_status', ['+V140']),
+            ('source_status', ['+S13']),
+        ]
+        result = _merge_zone_status_responses('sonance6', 1, responses)
+        assert result is not None
+        assert result['power'] == '1'
+        assert result['volume'] == '40'
+        assert result['source'] == '3'
+
+    def test_wrong_zone_is_skipped(self) -> None:
+        """Response for a different zone should not contaminate the merge."""
+        responses = [
+            ('zone_status',   ['+Z21']),   # zone 2, we want zone 1
+            ('volume_status', ['+V140']),  # zone 1 — correct
+        ]
+        result = _merge_zone_status_responses('sonance6', 1, responses)
+        # zone_status had no valid line; volume_status matched
+        assert result is not None
+        assert 'power' not in result
+        assert result['volume'] == '40'
+
+    def test_correct_line_picked_from_multi_line_response(self) -> None:
+        """When broadcast and real response arrive together, the right line wins."""
+        responses = [
+            # first line is zone 2 broadcast, second is the actual zone 1 response
+            ('zone_status',   ['+Z21', '+Z11']),
+            ('volume_status', ['+V140']),
+        ]
+        result = _merge_zone_status_responses('sonance6', 1, responses)
+        assert result is not None
+        assert result['power'] == '1'
+        assert result['zone'] == '1'
+
+    def test_all_wrong_zone_returns_none(self) -> None:
+        """If every response is for the wrong zone, return None."""
+        responses = [
+            ('zone_status',   ['+Z21']),
+            ('volume_status', ['+V240']),
+        ]
+        result = _merge_zone_status_responses('sonance6', 1, responses)
+        assert result is None
+
+    def test_empty_lines_returns_none(self) -> None:
+        """Empty line lists are silently skipped; all-empty → None."""
+        responses = [
+            ('zone_status',   []),
+            ('volume_status', []),
+        ]
+        result = _merge_zone_status_responses('sonance6', 1, responses)
+        assert result is None
+
+    def test_signed_eq_values_parsed(self) -> None:
+        """Negative EQ values in amp responses are parsed correctly."""
+        responses = [
+            ('zone_status',   ['+Z11']),
+            ('bass_status',   ['+L1-5']),
+            ('treble_status', ['+H1+7']),
+            ('balance_status',['+B1-3']),
+        ]
+        result = _merge_zone_status_responses('sonance6', 1, responses)
+        assert result is not None
+        assert result['bass']    == '-5'
+        assert result['treble']  == '+7'
+        assert result['balance'] == '-3'


### PR DESCRIPTION
## Sonance C4630 SE: fix EQ commands, response regex, and multi-query zone status

Tested on Sonance C4630 SE (6-zone). Three bugs prevented EQ and volume
status from working correctly with this amplifier.

### Changes

**`pyxantech/series/sonance6.yaml`**

Add `min_bass`, `min_treble`, `min_balance` to the device config. The
max values were already present but the min values were missing, causing
`get_device_config()` to return `None` for EQ minimums and the clamping
logic to silently floor at 0.

**`pyxantech/__init__.py`**

Fix EQ command clamping: `_set_bass_cmd`, `_set_treble_cmd`,
`_set_balance_cmd` all hardcoded `0` as the minimum. They now read
`min_bass`/`min_treble`/`min_balance` from device config (falling back
to `0`, so all other amp types are unaffected).

**`pyxantech/protocols/sonance.yaml`** — three fixes:

1. **Signed EQ commands**: `set_bass`/`set_treble`/`set_balance` used
   `{value:02}` which cannot represent negative numbers. Changed to
   `{value:+03d}` so negative values produce `:L1-05` instead of
   garbage.

2. **Multi-query zone status**: `:Z{zone}?` only returns power state on
   Sonance — not volume, source, mute, or EQ. Added `zone_status_queries`
   list; `__init__.py` now sends separate queries for each attribute and
   merges the results into one `ZoneStatus`. Non-Sonance amp types are
   unaffected (no `zone_status_queries` defined in their protocol).

3. **Response regex fixes**:
   - Volume: `\+V(?P<zone>\d+)(?P<volume>\d+)` was greedy — `+V460`
     matched as zone=46, volume=0. Fixed by restricting zone group to
     `[1-6]`.
   - Bass/treble/balance: patterns had spurious `BS`/`TR`/`BA` literals
     that don't appear in actual responses (device sends `+L1+5`, not
     `+L1BS+5`). Removed. Capture groups now match signed values with
     `[+-]?\d+`.

### Affected hardware

- Sonance C4630 SE (6-zone)
- Sonance 875D MKII (4-zone, same protocol — unverified)

Other amp types (xantech8, monoprice6, dax88, zpr68) are unaffected:
the `zone_status_queries` path is only taken when the protocol config
defines that key, and their EQ min-value fallback is `0` as before.
